### PR TITLE
cleanup: remove duplicated logs and requeue with error

### DIFF
--- a/controller/result.go
+++ b/controller/result.go
@@ -14,11 +14,6 @@ func RequeueOnError(err error) (ctrl.Result, error) {
 	return ctrl.Result{}, err
 }
 
-// RequeueWithError triggers a object requeue because the informed error happened.
-func RequeueWithError(err error) (ctrl.Result, error) {
-	return ctrl.Result{Requeue: true}, err
-}
-
 // NoRequeue all done, the object does not need reconciliation anymore.
 func NoRequeue() (ctrl.Result, error) {
 	return ctrl.Result{Requeue: false}, nil


### PR DESCRIPTION
This PR contains following cleanups :
- removal of the error log lines , which are already logged by the reconciler when returning the error from `reconcile` function
- no need to return `return ctrl.Result{Requeue: true}, err` as it is equivalent to `return ctrl.Result{}, err` , which will trigger another reconcile for the same CR ( and also log the error ). See https://github.com/kubernetes-sigs/controller-runtime/blob/75a38d2123d4696d24d8d3c6b2966e7a34442653/pkg/reconcile/reconcile.go#L93-L103